### PR TITLE
fix(ui): support lang code retrieval for DiffSingerRefinedPhonemizer

### DIFF
--- a/OpenUtau/Controls/PhonemeUIRender.cs
+++ b/OpenUtau/Controls/PhonemeUIRender.cs
@@ -18,6 +18,8 @@ namespace OpenUtau.App.Controls {
                 langCode = g2pPhonemizer.GetLangCode();
             } else if (track.Phonemizer is DiffSingerBasePhonemizer basePhonemizer) {
                 langCode = basePhonemizer.GetLangCode();
+            } else if (track.Phonemizer is DiffSingerRefinedPhonemizer refinedPhonemizer) {
+                langCode = refinedPhonemizer.GetLangCode();
             }
             return langCode;
         }


### PR DESCRIPTION
Update PhonemeUIRender to handle DiffSingerRefinedPhonemizer types when determining the language code for a voice part, being able to hide the language prefix